### PR TITLE
Add workaround for missing IEEE RewriteRules

### DIFF
--- a/test-data-validator/ieee_url_workaround.py
+++ b/test-data-validator/ieee_url_workaround.py
@@ -1,0 +1,83 @@
+# This workaround is necessary because IEEE schemas have $refs to schemas which don't resolve, because
+# they're missing version numbers. Once those w3id.org rewrite rules are fixed, this can be removed.
+from validator_types import SchemaId
+
+ieee_schema_directories = {
+    # environment
+    "ambient-light": "environment",
+    "ambient-sound": "environment",
+    "ambient-temperature": "environment",
+
+    # metadata
+    "data-point": "metadata",
+    "data-series": "metadata",
+    "header": "metadata",
+    "schema-id": "metadata",
+
+    # physical activity
+    "physical-activity": "physical_activity",
+
+    # sleep
+    "apnea-hypopnea-index": "sleep",
+    "arousal-index": "sleep",
+    "deep-sleep": "sleep",
+    "light-sleep": "sleep",
+    "sleep-episode": "sleep",
+    "sleep-onset-latency": "sleep",
+    "sleep-stage-summary": "sleep",
+    "snore-index": "sleep",
+    "time-in-bed": "sleep",
+    "total-sleep-time": "sleep",
+    "wake-after-sleep-onset": "sleep",
+
+    # survey
+    "survey-answer": "survey",
+    "survey-categorical-answer": "survey",
+    "survey-date-answer": "survey",
+    "survey-item": "survey",
+    "survey-question": "survey",
+    "survey-time-answer": "survey",
+    "survey-unit-value-answer": "survey",
+    "survey": "survey",
+
+    # utility
+    "body-posture": "utility",
+    "date-time": "utility",
+    "descriptive-statistic-denominator": "utility",
+    "descriptive-statistic": "utility",
+    "duration-unit-value-range": "utility",
+    "duration-unit-value": "utility",
+    "frequency-unit-value": "utility",
+    "illuminance-unit-value": "utility",
+    "kcal-unit-value": "utility",
+    "length-unit-value": "utility",
+    "percent-unit-value": "utility",
+    "sound-unit-value": "utility",
+    "speed-unit-value": "utility",
+    "temperature-unit-value": "utility",
+    "time-frame": "utility",
+    "time-interval": "utility",
+    "unit-value-range": "utility",
+    "unit-value": "utility",
+}
+
+ieee_schema_string_types = [
+    "body-posture",
+    "date-time",
+    "descriptive-statistic",
+    "descriptive-statistic-denominator"
+]
+
+
+def create_synthetic_ieee_schema(schema_id: SchemaId):
+    return \
+        {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$id": schema_id.base_uri,
+            "type": "string" if schema_id.name in ieee_schema_string_types else "object",
+            "allOf": [
+                {
+                    "$ref": "https://opensource.ieee.org/omh/1752/-/raw/main/schemas/{}/{}-1.0.json".format(ieee_schema_directories[schema_id.name], schema_id.name)
+                }
+            ]
+        }

--- a/test-data-validator/validator.py
+++ b/test-data-validator/validator.py
@@ -1,6 +1,7 @@
 import os
 from jsonschema import validate, RefResolver, ValidationError, draft202012_format_checker
-from validator_types import SchemaFile, DataFile
+from validator_types import SchemaFile, DataFile, SchemaId
+from ieee_url_workaround import ieee_schema_directories, create_synthetic_ieee_schema
 import sys
 import traceback
 
@@ -41,6 +42,19 @@ def load_schemas():
             total_loaded += 1
 
     print("Loaded {} schemas.".format(total_loaded))
+
+
+def load_synthetic_ieee_schemas():
+    total_loaded = 0
+    for schema_name in ieee_schema_directories.keys():
+        schema_id = SchemaId("ieee", schema_name)
+        schema_data = create_synthetic_ieee_schema(schema_id)
+        schema_file = SchemaFile(schema_id, schema_data, "synthetic")
+        record_schema_version(schema_file)
+        ref_resolver_store[schema_file.schema_id.base_uri] = schema_file.data
+        total_loaded += 1
+
+    print("Loaded {} synthetic IEEE schemas.".format(total_loaded))
 
 
 def validate_data_file_against_schema(data_file: DataFile, schema_file: SchemaFile):
@@ -127,5 +141,6 @@ def validate_data_files():
 
 
 load_schemas()
+load_synthetic_ieee_schemas()
 add_wildcard_versions_to_ref_resolver_store()
 validate_data_files()


### PR DESCRIPTION
## Problem
The [Apache `RewriteRule`s at w3id.org for the IEEE schemas](https://github.com/perma-id/w3id.org/blob/master/ieee/.htaccess) don't support fetching a schema by a versioned URL, breaking relative `$ref`s.

## Solution
Synthetic schemas are created that point to the [schemas on GitLab](https://opensource.ieee.org/omh/1752/), using a simple `allOf`. This workaround can be removed once the rewrite rules are fixed.