### PR TITLE
Use W3ID base URIs

### DIFF
--- a/test-data-validator/README.md
+++ b/test-data-validator/README.md
@@ -80,15 +80,15 @@ The validator is capable of resolving both local and remote schemas by their bas
 - You can use the absolute base URI of a remote schema in the `$ref` property of a local schema, and the validator will retrieve, cache, and use the remote schema.
 - You can create a test data file for a schema that only exists remotely, and the validator will similarly fetch and use the schema. For this to work, the suffix of the base URI of the remote schema must follow the `name-version.json` convention.  
 
-The validator constructs a base URI for a schema by mapping its schema namespace to a base URI prefix and appending its filename. The `omh` namespace is mapped to the `https://www.openmhealth.org/schema/omh` prefix, so the `omh:blood-glucose:3.0` schema has base URI `https://www.openmhealth.org/schema/omh/blood-glucose-3.0.json`.
+The validator constructs a base URI for a schema by mapping its schema namespace to a base URI prefix and appending its filename. The `omh` namespace is mapped to the `https://w3id.org/openmhealth/schemas/omh` prefix, so the `omh:blood-glucose:3.0` schema has base URI `https://w3id.org/openmhealth/schemas/omh/blood-glucose-3.0.json`.
 
 The following mappings are configured:
 
-| namespace | base URI prefix                            |
-|-----------|--------------------------------------------|
-| granola   | https://www.openmhealth.org/schema/granola |
-| ieee      | https://w3id.org/ieee/ieee-1752-schema     |
-| omh       | https://www.openmhealth.org/schema/omh     |
+| namespace | base URI prefix                              |
+|-----------|----------------------------------------------|
+| granola   | https://w3id.org/openmhealth/schemas/granola |
+| ieee      | https://w3id.org/ieee/ieee-1752-schema       |
+| omh       | https://w3id.org/openmhealth/schemas/omh     |
 
 
 To create a new namespace, add a dictionary entry to `schema_namespace_uris` in `validator_types.py`.

--- a/test-data-validator/validator.py
+++ b/test-data-validator/validator.py
@@ -9,8 +9,8 @@ schema_base_dir = '../schema'
 test_data_base_dir = '../test-data'
 
 # e.g. {
-#        "https://www.openmhealth.org/schema/omh/step-count-1.0.json" : <dict>,
-#        "https://www.openmhealth.org/schema/omh/step-count-1.x.json" : <dict>,
+#        "https://w3id.org/openmhealth/schemas/omh/step-count-1.0.json" : <dict>,
+#        "https://w3id.org/openmhealth/schemas/omh/step-count-2.0.json" : <dict>,
 #      }
 ref_resolver_store = {}
 

--- a/test-data-validator/validator_types.py
+++ b/test-data-validator/validator_types.py
@@ -4,9 +4,9 @@ import requests
 
 
 schema_namespace_uris = {
-    "granola": "https://www.openmhealth.org/schema/granola",
+    "granola": "https://w3id.org/openmhealth/schemas/granola",
     "ieee": "https://w3id.org/ieee/ieee-1752-schema",
-    "omh": "https://www.openmhealth.org/schema/omh",
+    "omh": "https://w3id.org/openmhealth/schemas/omh",
 }
 
 

--- a/test-data/omh/schema-id/1.1/shouldFail/invalid-url.json
+++ b/test-data/omh/schema-id/1.1/shouldFail/invalid-url.json
@@ -2,5 +2,5 @@
     "namespace": "omh",
     "name": "calories-burned",
     "version": "1.0",
-    "url": "://www.openmhealth.org/schema/omh/calories-burned-1.0.json"
+    "url": "://w3id.org/openmhealth/schemas/omh/calories-burned-1.0.json"
 }

--- a/test-data/omh/schema-id/1.1/shouldPass/with-url.json
+++ b/test-data/omh/schema-id/1.1/shouldPass/with-url.json
@@ -2,5 +2,5 @@
     "namespace": "omh",
     "name": "calories-burned",
     "version": "1.0",
-    "url": "http://www.openmhealth.org/schema/omh/calories-burned-1.0.json"
+    "url": "w3id.org/openmhealth/schemas/omh/calories-burned-1.0.json"
 }


### PR DESCRIPTION
## Problem
The Open mHealth website isn't correctly serving schemas. By attempting to serve the schemas from Wordpress, we're also coupling schema loading and data validation with the functioning of the OmH website.

## Solution
The schemas have been given permanent base URIs using [W3ID](https://w3id.org/). The redirection loads the schemas from GitHub, which is their authoritative source and works independently of the Open mHealth site.