### PR TITLE
Run validation job in CI when schemas change

### DIFF
--- a/.github/workflows/validator.yaml
+++ b/.github/workflows/validator.yaml
@@ -7,6 +7,7 @@ on:
       - "**"
     paths:
       - '.github/workflows/validator.yaml'
+      - 'schema/**'
       - 'test-data-validator/**'
       - 'test-data/**'
 
@@ -15,6 +16,7 @@ on:
       - "main"
     paths:
       - '.github/workflows/validator.yaml'
+      - 'schema/**'
       - 'test-data-validator/**'
       - 'test-data/**'
 
@@ -29,10 +31,10 @@ jobs:
         working-directory: ./test-data-validator
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
         


### PR DESCRIPTION
## Problem
When pushing changes to schemas, GitHub Actions isn't automatically running schema validation.

## Solution
The validation job has been updated to run when there are changes to the `schema` directory.