### PR TITLE
Feature/deprecate superseded

### DIFF
--- a/schema/omh/data-point-1.0.json
+++ b/schema/omh/data-point-1.0.json
@@ -1,5 +1,10 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
+    "deprecation": {
+        "reason": "This schema is now deprecated, in favor of the IEEE 1752.1 schema of the same name.",
+        "supersededBy": "https://w3id.org/ieee/ieee-1752-schema/data-point.json",
+        "date": "2026-06-14"
+    },
     "type": "object",
     "description": "This schema represents a data point.",
 

--- a/schema/omh/date-time-1.0.json
+++ b/schema/omh/date-time-1.0.json
@@ -1,5 +1,10 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
+    "deprecation": {
+        "reason": "This schema is now deprecated, in favor of the IEEE 1752.1 schema of the same name.",
+        "supersededBy": "https://w3id.org/ieee/ieee-1752-schema/date-time.json",
+        "date": "2026-06-14"
+    },
     "description": "This schema represents a point in time (ISO8601). If a timezone is not included, the timezone is assumed to be UTC.", 
     "type": "string",
     "references": [

--- a/schema/omh/descriptive-statistic-1.2.json
+++ b/schema/omh/descriptive-statistic-1.2.json
@@ -1,6 +1,10 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-
+    "deprecation": {
+        "reason": "This schema is now deprecated, in favor of the IEEE 1752.1 schema of the same name.",
+        "supersededBy": "https://w3id.org/ieee/ieee-1752-schema/descriptive-statistic.json",
+        "date": "2026-06-14"
+    },
     "description": "The descriptive statistic of a set of measurements. A measurement value can be the result of combining various measurements and calculating descriptive statistics like average, maximum, minimum, etc. Additional descriptive statistics will be added as the need arises. A measurement value without a descriptive statistic is interpreted as being the result of an individual measurement.",
     "type": "string",
 

--- a/schema/omh/descriptive-statistic-denominator-1.1.json
+++ b/schema/omh/descriptive-statistic-denominator-1.1.json
@@ -1,6 +1,10 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-
+    "deprecation": {
+        "reason": "This schema is now deprecated, in favor of the IEEE 1752.1 schema of the same name.",
+        "supersededBy": "https://w3id.org/ieee/ieee-1752-schema/descriptive-statistic-denominator.json",
+        "date": "2026-06-14"
+    },
     "description": "The denominator of the descriptive statistic when the measures has an implicit duration. For example in the context of step count, if the descriptive statistic is 'average' and the statistic denominator is 'd' the value describes average daily step count during the period delimited by the effective time frame; in the context of step count, if the descriptive statistic is 'maximum' and the statistic denominator is 'session' the value describes maximum step count per session during the period delimited by the effective time frame.",
     "type": "string",
     "enum": [

--- a/schema/omh/schema-id-1.1.json
+++ b/schema/omh/schema-id-1.1.json
@@ -1,6 +1,10 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-
+    "deprecation": {
+        "reason": "This schema is now deprecated, in favor of the IEEE 1752.1 schema of the same name.",
+        "supersededBy": "https://w3id.org/ieee/ieee-1752-schema/schema-id.json",
+        "date": "2026-06-14"
+    },
     "description": "This schema represents a JSON Schema identifier.",
 
     "type": "object",


### PR DESCRIPTION
Marked and documented as deprecated one set of schemas superseded by IEEE 1752 schemas of the same name. More schemas will undergo the same documentation is upcoming PRs
